### PR TITLE
Importable instance sets and a runnable test-app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+**kaval** is a Python CLI tool for orchestrating computational experiments across HPC environments. It reads YAML experiment suite files, expands parameter combinations (cartesian product), and submits jobs to SLURM clusters or runs them locally.
+
+## Setup
+
+```bash
+pipenv install       # install pyyaml dependency
+pipenv shell         # activate environment
+```
+
+## Running experiments
+
+```bash
+pipenv run python3 run-experiments.py <suite-name> --machine <target> [options]
+```
+
+Key flags:
+- `--machine`: `shared` | `horeka` | `supermuc` | `lichtenberg` | `generic-job-file`
+- `--search-dirs`: directories to search for `.suite.yaml` files
+- `--cores` / `--min-cores` / `--max-cores`: core count control; special tokens: `pow2` (1,2,4,…), `sqr` (1,4,9,16,…), `sqr-pow2` (powers of two that are also squares: 1,4,16,64,…), or `node-size-pow2` (tpn,2×tpn,… requires `--tasks-per-node`). The same tokens and `min_cores`/`max_cores` bounds may be set in the suite YAML (`ncores`, `min_cores`, `max_cores`); CLI flags override the suite values (defaults: min 1, max 8000).
+- `--fresh`: wipe experiment directory before running
+- `--test`: use test partition on SLURM clusters
+
+No automated test suite exists. Use the example suite to verify behavior. `examples/test-app` is a stand-in bash "binary" (echoes its args and writes a minimal JSON result); point `BUILD_DIR` at its parent so the suite's `executable: test-app` resolves:
+```bash
+BUILD_DIR=examples pipenv run python3 run-experiments.py test --machine shared --search-dirs examples/suites --output-dir /tmp/kaval_test
+```
+
+## Architecture
+
+### Entry point
+`run-experiments.py` — parses CLI args, resolves suite files, instantiates the right runner, and drives execution.
+
+### Core modules
+
+**`expcore.py`** — experiment model:
+- `ExperimentSuite` — loads and validates a `.suite.yaml` file
+- `FileInputGraph`, `KaGenGraph`, `DummyInstance` — input graph abstractions (file reference, generated, or placeholder)
+- `CLIArgumentType` — enum controlling how arguments are passed to the binary (`FLAGS`, `POSITIONAL`, `POSITIONAL_LIST`, `FLAG_LIST`)
+- Parameter expansion: YAML config lists are exploded into individual runs via cartesian product
+
+**`runners.py`** — execution backends:
+- `BaseRunner` — shared logic (directory management, command building, deduplication via JSON state files)
+- `SharedMemoryRunner` — executes directly via subprocess on the local machine
+- `SBatchRunner` (abstract) → `SuperMUCRunner`, `HorekaRunner`, `GenericDistributedMemoryRunner` — generate and submit SLURM job scripts; each specialization knows its cluster's node size and scheduler quirks
+- `get_runner()` — factory that selects the backend from `--machine`
+
+**`slugify.py`** — converts arbitrary strings to filesystem-safe slugs used in output directory naming.
+
+### Templates
+- `command-templates/` — shell snippets for how the binary is invoked (MPI flavors, binding strategies)
+- `sbatch-templates/` — SLURM job script skeletons per cluster
+
+### Suite YAML format
+See `examples/suites/test.suite.yaml` for a working example. Top-level keys include `executable`, `cores`, `seeds`, `graphs`, and `configurations`. Configurations support weak-scaling via `weak_scaling_graphs`.
+
+### Reusable instance sets
+To avoid repeating the same graphs across suites, define them once in a `*.instances.yaml` file (auto-discovered in `--search-dirs`, alongside `.suite.yaml` files). Each such file has a top-level `name` and a `graphs` list in the same format as a suite's `graphs`. A suite pulls a set in via an `import` entry in its own `graphs` list, and can mix imported sets with inline graphs:
+
+```yaml
+# common.instances.yaml
+name: common-graphs
+graphs:
+  - generator: kagen
+    type: rgg2d
+    N: [20, 22]
+```
+```yaml
+# my.suite.yaml
+graphs:
+  - import: common-graphs   # splices in every graph from the set
+  - generator: kagen        # inline graphs may be mixed in
+    type: rgg2d
+    N: 24
+```
+
+See `examples/suites/common.instances.yaml` and `examples/suites/import.suite.yaml`. Parsing lives in `expcore.load_instance_sets()` (discovery) and `expcore.parse_graph_list()` (expansion, incl. imports); unknown or circular imports raise a `ValueError`.

--- a/examples/suites/common.instances.yaml
+++ b/examples/suites/common.instances.yaml
@@ -1,0 +1,16 @@
+# A reusable instance set. Any *.instances.yaml file found in the search dirs
+# defines a named set of graphs (same format as a suite's `graphs` list) that
+# suites can pull in via `- import: <name>` entries in their own `graphs` list.
+name: common-graphs
+graphs:
+  - generator: dummy
+    name: my_graph
+    graph:
+      type: positional
+      value: /path/to/my/graph
+    queries:
+      type: flag_list
+      value: [[1, 2, 3, 4, 5, 6, 7, 8], [10, 9, 8, 7]]
+  - generator: kagen
+    type: rgg2d
+    N: [20, 22]

--- a/examples/suites/import.suite.yaml
+++ b/examples/suites/import.suite.yaml
@@ -1,0 +1,10 @@
+name: import-example
+executable: test-app # resolved under $BUILD_DIR; run with BUILD_DIR=examples
+ncores: [1, 64]
+graphs:
+  - import: common-graphs   # pulls in every graph from common.instances.yaml
+  - generator: kagen        # inline graphs can be mixed in freely
+    type: rgg2d
+    N: 24
+config:
+  variant: ["bfs1", "bfs2"]

--- a/examples/suites/test.suite.yaml
+++ b/examples/suites/test.suite.yaml
@@ -1,5 +1,5 @@
 name: test
-executable: /build/test_app
+executable: test-app # resolved under $BUILD_DIR; run with BUILD_DIR=examples
 ncores: [1, 64]
 time_limit: 61 # minutes
 seeds: [0, 1] # default: [0]

--- a/examples/test-app
+++ b/examples/test-app
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# A stand-in "binary" for exercising kaval end-to-end without a real build.
+# It echoes the arguments it received and, if a --json_output_path is given,
+# writes a minimal JSON results file there so the full output-path handling
+# (directory naming, per-config files) is exercised too.
+#
+# Point a suite's `executable` at this script by name and run kaval with
+# BUILD_DIR set to its parent directory, e.g.:
+#
+#   BUILD_DIR=examples pipenv run python3 run-experiments.py test \
+#       --machine shared --search-dirs examples/suites --output-dir /tmp/kaval_test
+
+set -euo pipefail
+
+json_output_path=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[i]}" == "--json_output_path" ]]; then
+        json_output_path="${args[i + 1]-}"
+    fi
+done
+
+echo "test-app invoked with: $*"
+
+if [[ -n "$json_output_path" ]]; then
+    out="${json_output_path}.json"
+    mkdir -p "$(dirname "$out")"
+    printf '{"app": "test-app", "args": "%s", "result": "ok"}\n' "$*" > "$out"
+    echo "wrote results to $out"
+fi

--- a/expcore.py
+++ b/expcore.py
@@ -486,7 +486,89 @@ class ExperimentSuite:
         return f"ExperimentSuite({self.name}, {self.cores}, {self.inputs}, {self.configs}, {self.time_limit}, {self.input_time_limit})"
 
 
-def load_suite_from_yaml(path):
+def load_instance_sets(search_paths):
+    """Discover reusable instance sets from ``*.instances.yaml`` files.
+
+    Each such file defines a named set of graphs (same format as a suite's
+    ``graphs`` list) via a top-level ``name`` and ``graphs`` key. The returned
+    dict maps set name to its raw graph list, ready to be spliced into a suite
+    that imports it.
+    """
+    instance_sets = {}
+    for path in search_paths:
+        if not path:
+            continue
+        for file in os.listdir(path):
+            if not file.endswith(".instances.yaml"):
+                continue
+            with open(os.path.join(path, file), "r") as f:
+                data = yaml.safe_load(f)
+            if not data or "graphs" not in data:
+                continue
+            name = data.get("name", file[: -len(".instances.yaml")])
+            instance_sets[name] = data["graphs"]
+    return instance_sets
+
+
+def parse_graph_list(graph_list, instance_sets=None, _seen=None):
+    """Expand a suite ``graphs`` list into InputGraph objects and time limits.
+
+    Entries of the form ``{"import": <name>}`` are replaced by the graphs of the
+    referenced instance set (see :func:`load_instance_sets`), recursively.
+    Returns ``(inputs, time_limits)``.
+    """
+    instance_sets = instance_sets or {}
+    _seen = _seen if _seen is not None else set()
+    inputs = []
+    time_limits = {}
+    for graph in graph_list:
+        if type(graph) == str:
+            inputs.append(graph)
+            continue
+        if "import" in graph:
+            set_name = graph["import"]
+            if set_name in _seen:
+                raise ValueError(
+                    f"Circular import of instance set '{set_name}'."
+                )
+            if set_name not in instance_sets:
+                raise ValueError(
+                    f"Unknown instance set '{set_name}'. "
+                    f"Available: {sorted(instance_sets)}."
+                )
+            _seen.add(set_name)
+            sub_inputs, sub_limits = parse_graph_list(
+                instance_sets[set_name], instance_sets, _seen
+            )
+            _seen.discard(set_name)
+            inputs.extend(sub_inputs)
+            time_limits.update(sub_limits)
+            continue
+        # copy so that shared instance-set definitions are not mutated
+        graph = copy.deepcopy(graph)
+        if "generator" in graph:
+            generator = graph.pop("generator")
+            if generator == "kagen":
+                inputs.extend(
+                    [KaGenGraph(**graph_variant) for graph_variant in explode(graph)]
+                )
+            elif generator == "dummy":
+                inputs.extend(
+                    [DummyInstance(**graph_variant) for graph_variant in explode(graph)]
+                )
+            else:
+                raise ValueError(
+                    f"'{generator}' is an unsupported argument for a graph generator. Use ['kagen', 'dummy'] instead."
+                )
+        else:
+            raise ValueError(f"No generator defined for graph: {graph}.")
+        time_limit = graph.get("time_limit")
+        if time_limit:
+            time_limits[graph["name"]] = time_limit
+    return inputs, time_limits
+
+
+def load_suite_from_yaml(path, instance_sets=None):
     with open(path, "r") as file:
         data = yaml.safe_load(file)
     configs = []
@@ -497,37 +579,7 @@ def load_suite_from_yaml(path):
             configs = configs + explode(config)
     else:
         configs = explode(data["config"])
-    inputs = []
-    time_limits = {}
-    for graph in data["graphs"]:
-        if type(graph) == str:
-            inputs.append(graph)
-        else:
-            if "generator" in graph:
-                generator = graph.pop("generator")
-                if generator == "kagen":
-                    inputs.extend(
-                        [
-                            KaGenGraph(**graph_variant)
-                            for graph_variant in explode(graph)
-                        ]
-                    )
-                elif generator == "dummy":
-                    inputs.extend(
-                        [
-                            DummyInstance(**graph_variant)
-                            for graph_variant in explode(graph)
-                        ]
-                    )
-                else:
-                    raise ValueError(
-                        f"'{generator}' is an unsupported argument for a graph generator. Use ['kagen', 'dummy'] instead."
-                    )
-            else:
-                raise ValueError(f"No generator defined for graph: {graph}.")
-            time_limit = graph.get("time_limit")
-            if time_limit:
-                time_limits[graph["name"]] = time_limit
+    inputs, time_limits = parse_graph_list(data["graphs"], instance_sets)
     if "executable" in data:
         executable = data["executable"]
     else:

--- a/run-experiments.py
+++ b/run-experiments.py
@@ -29,16 +29,19 @@ from pathlib import Path
 
 
 def load_suites(suite_files, search_paths):
+    instance_sets = expcore.load_instance_sets(search_paths)
     suites = {}
     for path in suite_files:
-        suite = expcore.load_suite_from_yaml(path)
+        suite = expcore.load_suite_from_yaml(path, instance_sets)
         suites[suite.name] = suite
     for path in search_paths:
         if not path:
             continue
         for file in os.listdir(path):
             if file.endswith(".suite.yaml"):
-                suite = expcore.load_suite_from_yaml(os.path.join(path, file))
+                suite = expcore.load_suite_from_yaml(
+                    os.path.join(path, file), instance_sets
+                )
                 suites[suite.name] = suite
     return suites
 


### PR DESCRIPTION
## Summary

Adds a way to define reusable graph/instance sets once and import them into any suite, so the same graphs no longer have to be repeated across suite files. Also adds a stand-in `test-app` so the example suites run end-to-end without a real build.

## Instance sets

- Define a set in a `*.instances.yaml` file (auto-discovered in `--search-dirs`, alongside `.suite.yaml` files) with a top-level `name` and a `graphs` list in the same format as a suite's `graphs`.
- Pull it into a suite via an `import` entry in the `graphs` list; imported sets and inline graphs mix freely and order is preserved:

```yaml
graphs:
  - import: common-graphs   # splices in every graph from the set
  - generator: kagen        # inline graphs still work alongside
    type: rgg2d
    N: 24
```

- Parsing refactored into `expcore.load_instance_sets()` (discovery) and `expcore.parse_graph_list()` (expansion incl. imports). Set definitions are deep-copied before mutation, so importing the same set into multiple suites is safe. Unknown or circular imports raise a `ValueError`.

## Runnable test-app

- `examples/test-app` is an executable bash stand-in "binary": it echoes its arguments and writes a minimal JSON result to `--json_output_path`, exercising the full output-path pipeline.
- Example suites now use `executable: test-app`, resolved via `BUILD_DIR=examples`.

## Files

- `expcore.py` — `load_instance_sets`, `parse_graph_list`, `load_suite_from_yaml(..., instance_sets)`
- `run-experiments.py` — `load_suites` discovers sets once and passes them to every suite
- `examples/test-app`, `examples/suites/common.instances.yaml`, `examples/suites/import.suite.yaml`
- `examples/suites/test.suite.yaml`, `CLAUDE.md` — updated docs/config

## Testing

- `import-example` suite expands to 5 inputs (4 imported + 1 inline) and generates correct commands.
- Existing `test.suite.yaml` still parses to its original 2 inputs.
- Full `shared`-machine run of the `test` suite: **0 / 64 failed**, real JSON output files produced.
- Re-importing the same set twice is stable (no mutation); unknown imports raise the expected error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)