### PR TITLE
Fix KaGen False-flag emission and param aliasing

### DIFF
--- a/expcore.py
+++ b/expcore.py
@@ -146,7 +146,10 @@ def stringify_params(params):
     param_strings = []
     for key, value in params.items():
         if isinstance(value, bool):
-            param_strings.append(key)
+            # KaGen reads a bare flag as true and its absence as false, so only
+            # emit the key when the flag is set; a False flag must be omitted.
+            if value:
+                param_strings.append(key)
         else:
             param_strings.append(f"{key}={value}")
     return param_strings
@@ -155,7 +158,9 @@ def stringify_params(params):
 class KaGenGraph(InputGraph):
 
     def __init__(self, **kwargs):
-        kwargs = kwargs.copy()
+        # deep copy so nested structures (e.g. extra_args) are not aliased
+        # across variants produced by explode()'s shallow copies
+        kwargs = copy.deepcopy(kwargs)
         try:
             self.type = kwargs.get("type")
         except KeyError:
@@ -320,7 +325,9 @@ class KaGenGraph(InputGraph):
 class DummyInstance(InputGraph):
     def __init__(self, **kwargs):
         self.name_ = kwargs["name"]
-        self.params = kwargs.copy()
+        # deep copy so nested param structures are not aliased across variants
+        # produced by explode()'s shallow copies
+        self.params = copy.deepcopy(kwargs)
         self.params.pop("name", None)
         self.parse_scale_weak_params(self.params)
         self.params.pop("scale_weak", None)


### PR DESCRIPTION
Two small, independent correctness fixes in `KaGenGraph` (unrelated to the instance-sets work in #7).

## 1. `False` boolean flags were emitted as enabled

`stringify_params` appended a bool param's key whenever the value was a bool, ignoring True/False. So a graph with `permute: False` rendered as `...;permute` in the KaGen option string — **silently turning the flag on** — and also collided in the generated name with the `permute: True` variant. KaGen treats a bare flag as true and its absence as false, so a `False` flag is now omitted from both the option string and the name.

```
permute=False -> type=rgg2d;n=262144                  (name: kagen_n18_typergg2d)
permute=True  -> type=rgg2d;permute;n=262144          (name: kagen_n18_typergg2d_permute)
```

## 2. Shallow-copied params aliased nested structures

`KaGenGraph` and `DummyInstance` stored their kwargs/params (including nested `extra_args`) via a shallow `.copy()`. Combined with `explode()`'s shallow copy for scalar-list expansion, variants of one graph entry ended up sharing the *same* nested `extra_args` dict object. Harmless today (nothing mutates it post-construction) but a latent aliasing hazard. The constructors now `copy.deepcopy` their params so each instance owns its own.

## Testing

- `permute: False`/`True` produce the option strings and distinct names shown above.
- Two `KaGenGraph`s built from the same `extra_args` dict no longer alias it (`is` → False).

🤖 Generated with [Claude Code](https://claude.com/claude-code)