### PR TITLE
Support flexible time-limit format

### DIFF
--- a/expcore.py
+++ b/expcore.py
@@ -57,6 +57,40 @@ def get_argument_type_from_str(arg_type: str) -> CLIArgumentType:
         sys.exit(1)
 
 
+def parse_time_limit(value):
+    """Parse a time limit to seconds.
+
+    Accepts:
+    - int or float, or a plain numeric string: interpreted as minutes
+    - suffix notation: combinations of d/h/m/s, e.g. "1h30m", "90m", "2h"
+    - colon-separated H:MM or H:MM:SS (hours:minutes[:seconds])
+    - SLURM day-prefix D-HH:MM:SS or D-HH:MM
+    """
+    if isinstance(value, (int, float)):
+        return int(value * 60)
+    s = str(value).strip()
+    try:
+        return int(float(s) * 60)
+    except ValueError:
+        pass
+    m = re.fullmatch(r'(\d+)-(\d+):(\d+)(?::(\d+))?', s)
+    if m:
+        d, h, mins, secs = m.groups()
+        return int(d) * 86400 + int(h) * 3600 + int(mins) * 60 + int(secs or 0)
+    m = re.fullmatch(r'(\d+):(\d+)(?::(\d+))?', s)
+    if m:
+        h, mins, secs = m.groups()
+        return int(h) * 3600 + int(mins) * 60 + int(secs or 0)
+    m = re.fullmatch(r'(?:(\d+(?:\.\d+)?)d)?(?:(\d+(?:\.\d+)?)h)?(?:(\d+(?:\.\d+)?)m)?(?:(\d+(?:\.\d+)?)s)?', s, re.IGNORECASE)
+    if m and any(g is not None for g in m.groups()):
+        d, h, mins, secs = (float(x) if x else 0.0 for x in m.groups())
+        return int(d * 86400 + h * 3600 + mins * 60 + secs)
+    raise ValueError(
+        f"Cannot parse time limit {value!r}. Use minutes (number), "
+        "'H:MM', 'H:MM:SS', 'D-HH:MM:SS', or suffix style like '1h30m'."
+    )
+
+
 def is_argument_flag_only(arg_type, arg_value):
     return arg_type == CLIArgumentType.FLAG and isinstance(arg_value, bool)
 
@@ -585,8 +619,8 @@ def parse_graph_list(graph_list, instance_sets=None, _seen=None, overrides=None)
         else:
             raise ValueError(f"No generator defined for graph: {graph}.")
         time_limit = graph.get("time_limit")
-        if time_limit:
-            time_limits[graph["name"]] = time_limit
+        if time_limit is not None:
+            time_limits[graph["name"]] = parse_time_limit(time_limit)
     return inputs, time_limits
 
 
@@ -657,7 +691,7 @@ def load_suite_from_yaml(path, instance_sets=None):
         inputs,
         configs,
         tasks_per_node=data.get("tasks_per_node"),
-        time_limit=data.get("time_limit"),
+        time_limit=parse_time_limit(data["time_limit"]) if "time_limit" in data else None,
         seeds=data.get("seeds", [0]),
         omit_seed=data.get("omit_seed", True),
         input_time_limit=time_limits,

--- a/run-experiments.py
+++ b/run-experiments.py
@@ -24,6 +24,7 @@
 
 from runners import *
 import expcore
+from expcore import parse_time_limit
 import argparse, os, sys
 from pathlib import Path
 
@@ -106,7 +107,10 @@ def main():
     parser.add_argument("--min-cores", default=None, type=int, help="Lower bound on core counts; overrides suite min_cores (default 1)")
     parser.add_argument("--cores", nargs="*", help="Override suite ncores with an explicit list of core counts or a special keyword: 'pow2' for powers of two (1,2,4,...), 'sqr' for square numbers (1,4,9,16,...), 'sqr-pow2' for powers of two that are also squares (1,4,16,64,...), 'node-size-pow2' for powers-of-two multiples of tasks_per_node")
     parser.add_argument(
-        "-t", "--time-limit", default=os.environ.get("TIME_LIMIT", None), type=int
+        "-t", "--time-limit",
+        default=parse_time_limit(os.environ["TIME_LIMIT"]) if "TIME_LIMIT" in os.environ else None,
+        type=parse_time_limit,
+        help="Time limit per job. Accepts minutes (number), 'H:MM', 'H:MM:SS', 'D-HH:MM:SS', or suffix style like '1h30m'.",
     )
 
     parser.add_argument("--test", action="store_true")

--- a/runners.py
+++ b/runners.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from expcore import ExperimentSuite
+from expcore import ExperimentSuite, parse_time_limit
 import expcore
 from pathlib import Path
 import subprocess, sys, json, os
@@ -402,12 +402,12 @@ class SBatchRunner(BaseRunner):
                                 mpi_ranks=mpi_ranks,
                                 threads_per_rank=threads_per_rank,
                                 ranks_per_node=ranks_per_node,
-                                timeout=job_time_limit * 60,
+                                timeout=job_time_limit,
                             )
                             commands.append(cmd_string)
                 subs["commands"] = "\n".join(commands)
                 subs["time_string"] = time.strftime(
-                    format_duration(seconds=time_limit * 60)
+                    format_duration(seconds=time_limit)
                 )
                 job_script = template.substitute(subs)
                 job_file = self.job_output_directory / aggregate_jobname


### PR DESCRIPTION
## Summary

- `--time-limit` and the YAML `time_limit` key previously only accepted an integer number of minutes
- Adds `parse_time_limit()` in `expcore.py` that parses to seconds (the new internal unit), accepting:
  - Plain number → minutes (backward-compatible)
  - Suffix style: `"1h30m"`, `"90m"`, `"2h"`, `"30s"`, or any combination
  - Colon-separated: `"1:30"` (H:MM) or `"1:30:00"` (H:MM:SS)
  - SLURM day-prefix: `"1-02:30:00"` (D-HH:MM:SS)
- Applied to CLI `--time-limit`, the `TIME_LIMIT` env var default, and YAML `time_limit` at both suite and per-graph level

🤖 Generated with [Claude Code](https://claude.com/claude-code)