### PR TITLE
Add --name/--prefix/--suffix to override output directory naming

### DIFF
--- a/run-experiments.py
+++ b/run-experiments.py
@@ -131,6 +131,18 @@ def main():
         action="store_true",
         help="Do not append a date suffix to the experiment data and output directories"
     )
+    parser.add_argument(
+        "--name",
+        help="Override the directory name for the suite. Errors if multiple suites would produce the same name.",
+    )
+    parser.add_argument(
+        "--prefix",
+        help="Prepend PREFIX_ to each suite's directory name.",
+    )
+    parser.add_argument(
+        "--suffix",
+        help="Append _SUFFIX to each suite's directory name (inserted before the date).",
+    )
 
     args = parser.parse_args()
     suites = load_suites(args.suite_files, args.search_dirs)
@@ -144,13 +156,30 @@ def main():
         sys.exit(0)
 
     if not args.suite:
-        args.suite = suites.keys()
+        args.suite = list(suites.keys())
 
-    for suitename in args.suite:
+    def effective_name(suite_name):
+        if args.name:
+            return args.name
+        name = suite_name
+        if args.prefix:
+            name = args.prefix + "_" + name
+        if args.suffix:
+            name = name + "_" + args.suffix
+        return name
+
+    active_suites = [s for s in args.suite if suites.get(s)]
+    names = [effective_name(s) for s in active_suites]
+    seen, dupes = set(), set()
+    for n in names:
+        (dupes if n in seen else seen).add(n)
+    if dupes:
+        sys.exit(f"Error: --name/--prefix/--suffix would produce duplicate directory names: {sorted(dupes)}")
+
+    for suitename in active_suites:
         suite = suites.get(suitename)
-        if suite:
-            runner = get_runner(args, suite)
-            runner.execute(suite)
+        runner = get_runner(args, suite, name_override=effective_name(suitename))
+        runner.execute(suite)
 
 
 if __name__ == "__main__":

--- a/runners.py
+++ b/runners.py
@@ -680,13 +680,14 @@ def _expand_cores_override(args, suite):
     return _expand_cores_tokens(args.cores, min_cores, max_cores, tpn)
 
 
-def get_runner(args, suite):
+def get_runner(args, suite, name_override=None):
     # print("type: ", suite.suite_type)
+    suite_name = name_override or suite.name
     date_suffix = not getattr(args, "no_date_suffix", False)
     min_cores, max_cores = _resolve_cores_bounds(args, suite)
     if args.machine == "shared":
         runner = SharedMemoryRunner(
-            suite.name,
+            suite_name,
             suite.output_path_option_name,
             max_cores,
             args.experiment_data_dir,
@@ -704,7 +705,7 @@ def get_runner(args, suite):
 
     elif args.machine in "supermuc":
         runner = SuperMUCRunner(
-            suite.name,
+            suite_name,
             suite.output_path_option_name,
             args.experiment_data_dir,
             args.machine,
@@ -724,7 +725,7 @@ def get_runner(args, suite):
         )
     elif args.machine in "horeka":
         runner = HorekaRunner(
-            suite.name,
+            suite_name,
             suite.output_path_option_name,
             args.experiment_data_dir,
             args.machine,
@@ -744,7 +745,7 @@ def get_runner(args, suite):
         )
     elif args.machine == "generic-job-file":
         runner = GenericDistributedMemoryRunner(
-            suite.name,
+            suite_name,
             suite.output_path_option_name,
             args.experiment_data_dir,
             args.machine,


### PR DESCRIPTION
## Summary

- `--name N` replaces the suite name used for the output directory entirely (e.g. `foo` → `N_26_07_02`); errors before any suite runs if multiple suites would map to the same name
- `--prefix P` prepends `P_` to each suite's directory name independently (e.g. `foo` → `P_foo_26_07_02`)
- `--suffix S` appends `_S` to each suite's directory name before the date (e.g. `foo` → `foo_S_26_07_02`)

The date suffix and `--no-date-suffix` interact with all three flags as before. Collision detection runs upfront so no partial work is done before the error is reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)