### PR TITLE
Fix per-instance time_limit for kagen/dummy graphs

### DIFF
--- a/expcore.py
+++ b/expcore.py
@@ -595,23 +595,21 @@ def parse_graph_list(graph_list, instance_sets=None, _seen=None, overrides=None)
             graph.update(copy.deepcopy(overrides))
         if "generator" in graph:
             generator = graph.pop("generator")
+            time_limit_val = graph.pop("time_limit", None)
             if generator == "kagen":
-                inputs.extend(
-                    [KaGenGraph(**graph_variant) for graph_variant in explode(graph)]
-                )
+                new_inputs = [KaGenGraph(**graph_variant) for graph_variant in explode(graph)]
             elif generator == "dummy":
-                inputs.extend(
-                    [DummyInstance(**graph_variant) for graph_variant in explode(graph)]
-                )
+                new_inputs = [DummyInstance(**graph_variant) for graph_variant in explode(graph)]
             else:
                 raise ValueError(
                     f"'{generator}' is an unsupported argument for a graph generator. Use ['kagen', 'dummy'] instead."
                 )
+            inputs.extend(new_inputs)
+            if time_limit_val is not None:
+                for inp in new_inputs:
+                    time_limits[inp.name] = parse_time_limit(time_limit_val)
         else:
             raise ValueError(f"No generator defined for graph: {graph}.")
-        time_limit = graph.get("time_limit")
-        if time_limit is not None:
-            time_limits[graph["name"]] = parse_time_limit(time_limit)
     return inputs, time_limits
 
 


### PR DESCRIPTION
## Summary

- `time_limit` was not removed from the graph dict before exploding and constructing `KaGenGraph`/`DummyInstance` objects, so it leaked into their params — corrupting KaGen option strings, instance names, and CLI args passed to the binary
- The fallback `graph["name"]` lookup then failed with a `KeyError` for KaGen graphs (which have no explicit `name` key in YAML), meaning per-instance time limits were silently dropped
- The same bug affected `DummyInstance` (name is also computed, not a raw dict key)

Fix: pop `time_limit` from the graph dict before exploding, then register it against each exploded instance's computed `.name`. This correctly handles the case where a single graph spec explodes into multiple variants (e.g. `N: [20, 22]`) — each variant gets the time limit.

## Test plan

- [ ] Manually verified with inline Python: `KaGenGraph` and `DummyInstance` no longer receive `time_limit` in their kwargs, and the returned `time_limits` dict is keyed by the correct computed instance names
- [ ] Covers single-variant and multi-variant (exploded) cases
- [ ] Covers both `kagen` and `dummy` generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)