### PR TITLE
Add file-graph registry for real-world graphs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ BUILD_DIR=examples pipenv run python3 run-experiments.py test --machine shared -
 
 **`expcore.py`** — experiment model:
 - `ExperimentSuite` — loads and validates a `.suite.yaml` file
-- `FileInputGraph`, `KaGenGraph`, `DummyInstance` — input graph abstractions (file reference, generated, or placeholder)
+- `KaGenGraph`, `DummyInstance` — input graph abstractions (KaGen-generated or file-based, or placeholder)
 - `CLIArgumentType` — enum controlling how arguments are passed to the binary (`FLAGS`, `POSITIONAL`, `POSITIONAL_LIST`, `FLAG_LIST`)
 - Parameter expansion: YAML config lists are exploded into individual runs via cartesian product
 
@@ -95,4 +95,27 @@ A `with:` on a bare-string file input can't be applied — it is logged and the 
 
 **Deduplication** — after all imports and modifications resolve, the input list is de-duplicated by graph name (first occurrence kept, order preserved), so diamond imports (two sets importing a common set) or an inline graph that duplicates an imported one don't produce repeated runs. Dropped names are logged.
 
-See `examples/suites/common.instances.yaml` and `examples/suites/import.suite.yaml`. Parsing lives in `expcore.load_instance_sets()` (discovery) and `expcore.parse_graph_list()` (expansion, incl. imports and `with:` overrides); dedup is `expcore.dedup_inputs()`, applied in `load_suite_from_yaml()`.
+**File-graph registry (`graph_name` / `root`)** — real, on-disk graphs (parhip/metis/etc.) need no dedicated abstraction: they're ordinary `generator: kagen, type: file` (or `type: partitioned_file`) entries, so the import/`with:`/dedup pipeline above applies to them unchanged. `KaGenGraph` accepts two extra sugar params for this case:
+
+- `graph_name` — a friendly handle used as the file-identifying part of both `.name` (the dedup/time-limit key) and `.short_name` (output-directory naming), instead of the raw `filename`. Without it, every `type: file` graph's `short_name` collapses to the literal string `file`, colliding across any suite with multiple real-world graphs.
+- `root` — an optional directory prefix. When `filename` is relative, it's joined onto `root` when the command is built, not when the YAML is parsed — so `root` remains a normal, overridable param through `with:`. `root` also expands `$VAR`/`${VAR}` references, so a checked-in registry works unmodified across clusters that each set the referenced variable (e.g. `GRAPH_ROOT`) via their existing environment setup, mirroring how `BUILD_DIR` locates the executable per-machine. An unset variable raises a `ValueError` when the suite loads, rather than embedding a literal `$GRAPH_ROOT` in a generated sbatch script.
+
+```yaml
+# real-world.instances.yaml
+name: real-world-graphs
+graphs:
+  - generator: kagen
+    type: file
+    graph_name: example-graph
+    root: ${GRAPH_ROOT}
+    filename: example-graph.graph
+```
+```yaml
+# my.suite.yaml
+graphs:
+  - import: real-world-graphs
+    with:
+      root: /scratch/other-graphs   # override for one run
+```
+
+See `examples/suites/common.instances.yaml`, `examples/suites/real-world.instances.yaml`, and `examples/suites/import.suite.yaml`. Parsing lives in `expcore.load_instance_sets()` (discovery) and `expcore.parse_graph_list()` (expansion, incl. imports and `with:` overrides); dedup is `expcore.dedup_inputs()`, applied in `load_suite_from_yaml()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ BUILD_DIR=examples pipenv run python3 run-experiments.py test --machine shared -
 
 **`expcore.py`** — experiment model:
 - `ExperimentSuite` — loads and validates a `.suite.yaml` file
-- `KaGenGraph`, `DummyInstance` — input graph abstractions (KaGen-generated or file-based, or placeholder)
+- `KaGenGraph`, `GenericInstance` — input abstractions (KaGen-generated/file-based, or a generic pass-through of arbitrary CLI params for any other binary, e.g. a string generator)
 - `CLIArgumentType` — enum controlling how arguments are passed to the binary (`FLAGS`, `POSITIONAL`, `POSITIONAL_LIST`, `FLAG_LIST`)
 - Parameter expansion: YAML config lists are exploded into individual runs via cartesian product
 
@@ -57,10 +57,12 @@ BUILD_DIR=examples pipenv run python3 run-experiments.py test --machine shared -
 - `sbatch-templates/` — SLURM job script skeletons per cluster
 
 ### Suite YAML format
-See `examples/suites/test.suite.yaml` for a working example. Top-level keys include `executable`, `cores`, `seeds`, `graphs`, and `configurations`. Configurations support weak-scaling via `weak_scaling_graphs`.
+See `examples/suites/test.suite.yaml` for a working example. Top-level keys include `executable`, `cores`, `seeds`, `graphs` (or `inputs` — an alias; kaval is used for non-graph experiments too, e.g. string sorting, where `inputs` reads more naturally), and `configurations`. Configurations support weak-scaling via `weak_scaling_graphs`.
+
+Each `graphs`/`inputs` entry picks a generator via `generator: kagen | generic`. `generic` (`dummy` also still accepted, as a legacy alias) passes its remaining keys straight through as CLI params to `executable` — the mechanism for any generator that isn't KaGen (e.g. a colleague's string generator), not a placeholder despite the old name. See `examples/suites/generic-input.suite.yaml` for the `inputs:`/`generic` spelling.
 
 ### Reusable instance sets
-To avoid repeating the same graphs across suites, define them once in a `*.instances.yaml` file (auto-discovered in `--search-dirs`, alongside `.suite.yaml` files). Each such file has a top-level `name` and a `graphs` list in the same format as a suite's `graphs`. A suite pulls a set in via an `import` entry in its own `graphs` list, and can mix imported sets with inline graphs:
+To avoid repeating the same inputs across suites, define them once in a `*.instances.yaml` file (auto-discovered in `--search-dirs`, alongside `.suite.yaml` files). Each such file has a top-level `name` and a `graphs`/`inputs` list in the same format as a suite's. A suite pulls a set in via an `import` entry in its own `graphs`/`inputs` list, and can mix imported sets with inline graphs:
 
 ```yaml
 # common.instances.yaml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# kaval
+
+A Python CLI for orchestrating computational experiments across HPC environments.
+It reads YAML experiment suite files, expands parameter combinations (cartesian
+product), and submits jobs to SLURM clusters or runs them locally.
+
+## Install
+
+```bash
+pipenv install
+pipenv shell
+```
+
+## Quick start
+
+`run-experiments.py` takes a suite name, resolves it from `.suite.yaml` files in
+your `--search-dirs`, and either runs it locally or generates/submits SLURM job
+scripts, depending on `--machine`.
+
+```bash
+pipenv run python3 run-experiments.py <suite-name> --machine <target> [options]
+```
+
+To try it against the bundled example (a stand-in bash "binary" that just echoes
+its args):
+
+```bash
+BUILD_DIR=examples pipenv run python3 run-experiments.py test \
+  --machine shared --search-dirs examples/suites --output-dir /tmp/kaval_test
+```
+
+`--machine` selects the execution backend: `shared` | `horeka` | `supermuc` |
+`lichtenberg` | `generic-job-file`.
+
+## Learn more
+
+See [`CLAUDE.md`](CLAUDE.md) for the full suite-YAML format, the reusable
+instance-set / file-graph-registry mechanism, module architecture, and other
+CLI flags (`--cores`, `--fresh`, `--test`, etc.).

--- a/examples/suites/generic-input.suite.yaml
+++ b/examples/suites/generic-input.suite.yaml
@@ -1,0 +1,15 @@
+# Demonstrates the `inputs:` key (alias for `graphs:`) and `generator: generic`
+# (alias for the legacy `dummy` name) -- for suites whose inputs aren't graphs,
+# e.g. a string-sorting benchmark. See test.suite.yaml for the graphs:/dummy
+# spelling, which still works unchanged.
+name: generic-input-example
+executable: test-app # resolved under $BUILD_DIR; run with BUILD_DIR=examples
+ncores: [1, 64]
+inputs:
+  - generator: generic
+    name: strings
+    string-generator: 1
+    len-strings: 500
+    num-strings: [10000, 100000]
+config:
+  num-iterations: [5]

--- a/examples/suites/import.suite.yaml
+++ b/examples/suites/import.suite.yaml
@@ -2,8 +2,9 @@ name: import-example
 executable: test-app # resolved under $BUILD_DIR; run with BUILD_DIR=examples
 ncores: [1, 64]
 graphs:
-  - import: common-graphs   # pulls in every graph from common.instances.yaml
-  - generator: kagen        # inline graphs can be mixed in freely
+  - import: common-graphs      # pulls in every graph from common.instances.yaml
+  - import: real-world-graphs  # pulls in the on-disk graph registry
+  - generator: kagen           # inline graphs can be mixed in freely
     type: rgg2d
     N: 24
 config:

--- a/examples/suites/real-world.instances.yaml
+++ b/examples/suites/real-world.instances.yaml
@@ -1,0 +1,22 @@
+# A registry of on-disk graphs, named once via `graph_name` and referenced by
+# suites through the normal import mechanism. `root` is a directory prefix
+# joined onto a relative `filename` when the command is built (not at parse
+# time), so it stays overridable via `with:` and supports env-var expansion
+# (e.g. `root: ${GRAPH_ROOT}`) for per-cluster dataset locations (same
+# indirection pattern as BUILD_DIR) -- kept as a literal path here so this
+# example runs out of the box without requiring an external env var; see
+# CLAUDE.md for the env-var form.
+name: real-world-graphs
+graphs:
+  - generator: kagen
+    type: file
+    graph_name: example-graph-a
+    root: examples/graphs
+    filename: graph-a.graph   # placeholder; not read by examples/test-app
+    input_format: metis
+  - generator: kagen
+    type: file
+    graph_name: example-graph-b
+    root: examples/graphs
+    filename: graph-b.graph
+    input_format: metis

--- a/expcore.py
+++ b/expcore.py
@@ -126,54 +126,24 @@ class InputGraph:
         return self.name
 
 
-class FileInputGraph(InputGraph):
-    def __init__(self, name, path, format="metis"):
-        self._name = slugify.slugify(name)
-        self.path = path
-        self.format = format
-        self.partitions = {}
-        self.partitioned = False
+_ENV_VAR_RE = re.compile(r'\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*')
 
-    def args(self, mpi_ranks, threads_per_rank, escape):
-        # file_args = [str(self.path), "--input-format", self.format]
-        file_args = ["--graphtype", "BRAIN", "--infile_dir", str(self.path)]
-        if self.partitioned and mpi_ranks > 1:
-            partition_file = self.partitions.get(mpi_ranks, None)
-            if not partition_file:
-                logging.error(
-                    f"Could not load partitioning for p={mpi_ranks} for input {self.name}"
-                )
-                sys.exit(1)
-            file_args += ["--partitioning", partition_file]
-        return file_args
 
-    def add_partitions(self, partitions):
-        self.partitions.update(partitions)
+def expand_env_vars_or_raise(value):
+    """Expand $VAR/${VAR} references in `value` via os.path.expandvars.
 
-    @property
-    def name(self):
-        if self.partitioned:
-            return self._name + "_partitioned"
-        else:
-            return self._name
-
-    @name.setter
-    def name(self, value):
-        self._name = value
-
-    def exists(self):
-        if self.format == "metis":
-            return self.path.exists()
-        elif self.format == "binary":
-            root = self.path.parent
-            first_out = root / (self.path.stem + ".first_out")
-            head = root / (self.path.stem + ".head")
-            return first_out.exists() and head.exists()
-        elif self.format == "brain_format":
-            return True
-
-    def __repr__(self):
-        return f"FileInputGraph({self.name, self.path, self.format, self.partitioned, self.partitions})"
+    Raises ValueError if a reference is left unresolved (i.e. the env var is
+    unset), so the problem surfaces as a suite-load error instead of a literal
+    '$VAR' ending up in a generated sbatch script.
+    """
+    expanded = os.path.expandvars(value)
+    m = _ENV_VAR_RE.search(expanded)
+    if m:
+        raise ValueError(
+            f"Unresolved environment variable {m.group(0)!r} in root {value!r}. "
+            "Set it in the environment before loading suites."
+        )
+    return expanded
 
 
 def stringify_params(params):
@@ -219,6 +189,9 @@ class KaGenGraph(InputGraph):
         kwargs.pop("scale_weak", False)
         kwargs.pop("extra_args", None)
         kwargs.pop("extra_args_scale_weak", None)
+        self.graph_name = kwargs.pop("graph_name", None)
+        root = kwargs.pop("root", None)
+        self.root = expand_env_vars_or_raise(root) if root is not None else None
         self.params = kwargs
 
     def parse_scale_weak_params(self, kwargs):
@@ -292,6 +265,11 @@ class KaGenGraph(InputGraph):
 
     def preprocess_file_based_graphs_params(self, mpi_ranks):
         params = self.params.copy()
+        file_types = ("file", "partitioned_file", "partitioned-file")
+        if self.root and params.get("type") in file_types and "filename" in params:
+            filename = params["filename"]
+            if not os.path.isabs(filename):
+                params["filename"] = os.path.join(self.root, filename)
         if params.get("type") not in ["partitioned_file", "partitioned-file"]:
             return params
         try:
@@ -332,7 +310,10 @@ class KaGenGraph(InputGraph):
             params.append(f"n={int(math.log2(self.n))}")
         if self.m:
             params.append(f"m={int(math.log2(self.m))}")
-        params += stringify_params(self.params)
+        name_params = self.params
+        if self.graph_name and "filename" in self.params:
+            name_params = {**self.params, "filename": self.graph_name}
+        params += stringify_params(name_params)
         if self.scale_weak:
             params.append("weak")
         # include extra_args compactly
@@ -350,7 +331,10 @@ class KaGenGraph(InputGraph):
 
     @property
     def short_name(self):
-        name = f"{self.params['type']}"
+        if self.graph_name and "filename" in self.params:
+            name = self.graph_name
+        else:
+            name = f"{self.params['type']}"
         if self.n:
             name += f"_n={int(math.log2(self.n))}"
         return slugify.slugify(name)
@@ -489,30 +473,6 @@ class ExperimentSuite:
 
     def get_input_time_limit(self, input_name):
         return self.input_time_limit.get(input_name, self.time_limit)
-
-    def load_inputs(self, input_dict, partitions):
-        inputs_new = []
-        for graph in self.inputs:
-            if isinstance(graph, str):
-                graph = {"name": graph, "partitioned": False}
-            elif isinstance(graph, tuple):
-                graph_name, partitioned = graph
-                graph = {"name": graph_name, "partitioned": partitioned}
-            else:
-                inputs_new.append(graph)
-                continue
-            input = copy.copy(input_dict.get(graph["name"]))
-            if not input:
-                logging.warn(f"Could not load input for {graph_name}")
-                continue
-            if graph["partitioned"]:
-                input.add_partitions(partitions.get(graph["name"], {}))
-                input.partitioned = graph["partitioned"]
-            # print(input)
-            inputs_new.append(input)
-
-        self.inputs = inputs_new
-        # print(self.inputs)
 
     def __repr__(self):
         return f"ExperimentSuite({self.name}, {self.cores}, {self.inputs}, {self.configs}, {self.time_limit}, {self.input_time_limit})"

--- a/expcore.py
+++ b/expcore.py
@@ -177,7 +177,7 @@ class KaGenGraph(InputGraph):
             self.m = kwargs.get("m", 1 << int(kwargs["M"]))
         except (TypeError, KeyError):
             self.m = None
-        # handle extra_args similar to DummyInstance
+        # handle extra_args similar to GenericInstance
         self.extra_args = kwargs.get("extra_args", {})
         self.parse_scale_weak_params({"scale_weak": kwargs.get("extra_args_scale_weak")})
         # cleanup consumed keys
@@ -340,7 +340,7 @@ class KaGenGraph(InputGraph):
         return slugify.slugify(name)
 
 
-class DummyInstance(InputGraph):
+class GenericInstance(InputGraph):
     def __init__(self, **kwargs):
         self.name_ = kwargs["name"]
         # deep copy so nested param structures are not aliased across variants
@@ -478,13 +478,31 @@ class ExperimentSuite:
         return f"ExperimentSuite({self.name}, {self.cores}, {self.inputs}, {self.configs}, {self.time_limit}, {self.input_time_limit})"
 
 
+def get_input_list(data, context=""):
+    """Look up a suite/instance-set's input list under ``graphs`` or ``inputs``.
+
+    ``graphs`` is the original, still-primary key; ``inputs`` is an alias for
+    suites whose inputs aren't graphs (e.g. string-sorting instances) and would
+    read oddly under ``graphs``. Both name the same list format. Specifying
+    both is ambiguous and rejected. Returns ``None`` if neither key is present.
+    """
+    if "graphs" in data and "inputs" in data:
+        where = f" in {context}" if context else ""
+        raise ValueError(f"Specify only one of 'graphs' or 'inputs'{where}, not both.")
+    if "graphs" in data:
+        return data["graphs"]
+    if "inputs" in data:
+        return data["inputs"]
+    return None
+
+
 def load_instance_sets(search_paths):
     """Discover reusable instance sets from ``*.instances.yaml`` files.
 
-    Each such file defines a named set of graphs (same format as a suite's
-    ``graphs`` list) via a top-level ``name`` and ``graphs`` key. The returned
-    dict maps set name to its raw graph list, ready to be spliced into a suite
-    that imports it.
+    Each such file defines a named set of inputs (same format as a suite's
+    ``graphs``/``inputs`` list) via a top-level ``name`` and ``graphs`` (or
+    ``inputs``) key. The returned dict maps set name to its raw input list,
+    ready to be spliced into a suite that imports it.
     """
     instance_sets = {}
     for path in search_paths:
@@ -495,10 +513,13 @@ def load_instance_sets(search_paths):
                 continue
             with open(os.path.join(path, file), "r") as f:
                 data = yaml.safe_load(f)
-            if not data or "graphs" not in data:
+            if not data:
+                continue
+            input_list = get_input_list(data, file)
+            if input_list is None:
                 continue
             name = data.get("name", file[: -len(".instances.yaml")])
-            instance_sets[name] = data["graphs"]
+            instance_sets[name] = input_list
     return instance_sets
 
 
@@ -558,11 +579,11 @@ def parse_graph_list(graph_list, instance_sets=None, _seen=None, overrides=None)
             time_limit_val = graph.pop("time_limit", None)
             if generator == "kagen":
                 new_inputs = [KaGenGraph(**graph_variant) for graph_variant in explode(graph)]
-            elif generator == "dummy":
-                new_inputs = [DummyInstance(**graph_variant) for graph_variant in explode(graph)]
+            elif generator in ("generic", "dummy"):
+                new_inputs = [GenericInstance(**graph_variant) for graph_variant in explode(graph)]
             else:
                 raise ValueError(
-                    f"'{generator}' is an unsupported argument for a graph generator. Use ['kagen', 'dummy'] instead."
+                    f"'{generator}' is an unsupported input generator. Use ['kagen', 'generic'] instead."
                 )
             inputs.extend(new_inputs)
             if time_limit_val is not None:
@@ -577,7 +598,7 @@ def _input_key(graph):
     """Identity of an input for deduplication.
 
     Two inputs are considered the same run if they produce the same name:
-    ``KaGenGraph``/``DummyInstance`` names are derived from all their params,
+    ``KaGenGraph``/``GenericInstance`` names are derived from all their params,
     and bare file references are just their string.
     """
     if isinstance(graph, InputGraph):
@@ -620,7 +641,10 @@ def load_suite_from_yaml(path, instance_sets=None):
             configs = configs + explode_with_env(config)
     else:
         configs = explode_with_env(data["config"])
-    inputs, time_limits = parse_graph_list(data["graphs"], instance_sets)
+    input_list = get_input_list(data, path)
+    if input_list is None:
+        raise ValueError(f"Suite '{path}' is missing a 'graphs' (or 'inputs') list.")
+    inputs, time_limits = parse_graph_list(input_list, instance_sets)
     inputs = dedup_inputs(inputs)
     if "executable" in data:
         executable = data["executable"]

--- a/expcore.py
+++ b/expcore.py
@@ -37,10 +37,10 @@ import slugify
 
 
 class CLIArgumentType(Enum):
-    FLAG = ("flag",)
+    FLAG = "flag"
     POSITIONAL = "positional"
     POSITIONAL_LIST = "positional_list"
-    FLAG_LIST = "positional_list"
+    FLAG_LIST = "flag_list"
 
 
 def get_argument_type_from_str(arg_type: str) -> CLIArgumentType:
@@ -265,12 +265,12 @@ class KaGenGraph(InputGraph):
 
     def preprocess_file_based_graphs_params(self, mpi_ranks):
         params = self.params.copy()
-        file_types = ("file", "partitioned_file", "partitioned-file")
+        file_types = ("file", "partitioned_file")
         if self.root and params.get("type") in file_types and "filename" in params:
             filename = params["filename"]
             if not os.path.isabs(filename):
                 params["filename"] = os.path.join(self.root, filename)
-        if params.get("type") not in ["partitioned_file", "partitioned-file"]:
+        if params.get("type") != "partitioned_file":
             return params
         try:
             filename = params.get("filename")
@@ -285,7 +285,7 @@ class KaGenGraph(InputGraph):
         )
         params["filename"] = extended_filename
         params["distribution"] = "explicit"
-        params["explicit-distribution"] = extended_filename + ".partitions"
+        params["explicit_distribution"] = extended_filename + ".partitions"
         return params
 
     def args(self, mpi_ranks, threads_per_rank, escape):


### PR DESCRIPTION
## Summary
- Real-world graphs (parhip/metis/etc.) can now be named once via `graph_name` and referenced by suites through the existing `import`/`with:`/dedup pipeline, instead of pasting full paths everywhere. `root` provides an optional, env-var-expandable directory prefix (e.g. `root: ${GRAPH_ROOT}`), joined lazily at command-build time so it stays overridable via `with:` and unresolved variables raise a clear `ValueError` at suite-load time — mirroring the existing `BUILD_DIR` per-cluster indirection pattern.
- Fixes a real bug: `KaGenGraph.short_name` collapsed to the literal string `"file"` for every `type: file` graph, colliding output directory names across any suite with multiple real-world graphs.
- Removes `FileInputGraph`/`ExperimentSuite.load_inputs`, which predated KaGen's own file-reading support, hardcoded a different binary's CLI flags (`--graphtype BRAIN`), and were dead code unreferenced by the current suite-loading path.
- Fixes `explicit-distribution` -> `explicit_distribution`: KaGen's option parser reads the underscore form; the hyphenated key was silently ignored, so `partitioned_file`'s explicit distribution never actually reached KaGen.
- Fixes `CLIArgumentType.FLAG_LIST` aliasing `POSITIONAL_LIST` (identical enum values collapse into the same member in Python), which silently turned `type: flag_list` arguments into positional ones. `test.suite.yaml`'s `queries` example now correctly emits `--queries "1" "2" ...` instead of a bare list.
- Collapses the `partitioned_file`/`partitioned-file` dual spelling to just `partitioned_file`.
- Adds `inputs:` as an alias for `graphs:`, and `generator: generic` as an alias for `generator: dummy` (both legacy spellings still work) — kaval turns out to already be used for non-graph experiments (a colleague's string-sorting suite), where the graph-flavored vocabulary reads oddly and "dummy" misleadingly suggests a stub. Internal `DummyInstance` renamed to `GenericInstance`.
- Adds a quick-start `README.md` pointing to `CLAUDE.md` for full docs.

## Test plan
- [x] `BUILD_DIR=examples pipenv run python3 run-experiments.py test --machine shared --search-dirs examples/suites --output-dir /tmp/...` — no regression from removing `FileInputGraph`
- [x] `BUILD_DIR=examples GRAPH_ROOT=examples/graphs pipenv run python3 run-experiments.py import-example --machine shared --search-dirs examples/suites --output-dir /tmp/...` — `example-graph-a`/`example-graph-b` get distinct output directories (short_name fix), `root`/`filename` join correctly in `--kagen_option_string`
- [x] `with: {root: ...}` override on an `import: real-world-graphs` entry correctly overrides the joined path
- [x] An unresolved `${VAR}` in `root` raises `ValueError` at suite-load time
- [x] Two imports of the same registry set are correctly de-duplicated, keyed on the `graph_name`-based name
- [x] `partitioned_file` type emits `distribution=explicit;explicit_distribution=...` (underscore, matching KaGen's parser)
- [x] `test.suite.yaml`'s `queries` (`type: flag_list`) now emits `--queries "1" "2" "3" ...` instead of a bare positional list
- [x] A colleague's actual `graphs:`/`generator: dummy` suite still parses and builds identical commands unchanged
- [x] `inputs:`/`generator: generic` (new spelling) resolves to the same `GenericInstance` and produces identical args
- [x] Specifying both `graphs:` and `inputs:` in one file raises a clear `ValueError`
- [x] `BUILD_DIR=examples pipenv run python3 run-experiments.py generic-input-example --machine shared --search-dirs examples/suites --output-dir /tmp/...` runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)