### PR TITLE
Add file-level default root: for instance-set files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,14 +102,16 @@ A `with:` on a bare-string file input can't be applied — it is logged and the 
 - `graph_name` — a friendly handle used as the file-identifying part of both `.name` (the dedup/time-limit key) and `.short_name` (output-directory naming), instead of the raw `filename`. Without it, every `type: file` graph's `short_name` collapses to the literal string `file`, colliding across any suite with multiple real-world graphs.
 - `root` — an optional directory prefix. When `filename` is relative, it's joined onto `root` when the command is built, not when the YAML is parsed — so `root` remains a normal, overridable param through `with:`. `root` also expands `$VAR`/`${VAR}` references, so a checked-in registry works unmodified across clusters that each set the referenced variable (e.g. `GRAPH_ROOT`) via their existing environment setup, mirroring how `BUILD_DIR` locates the executable per-machine. An unset variable raises a `ValueError` when the suite loads, rather than embedding a literal `$GRAPH_ROOT` in a generated sbatch script.
 
+A `*.instances.yaml` file may also set a top-level `root:`, applied as a default to every `generator: kagen` entry in that file that has a `filename` and doesn't already set its own `root` — so a registry of many file-based graphs doesn't need `root` repeated on each one. It's skipped for `import` entries and non-file graphs mixed into the same file, so those never inherit a root/env-var requirement they don't need; an entry's own `root`, or a `with: {root: ...}` override at the import site, still wins over the file-level default. Implemented in `expcore.apply_default_root()`, applied in `load_instance_sets()`.
+
 ```yaml
 # real-world.instances.yaml
 name: real-world-graphs
+root: ${GRAPH_ROOT}   # default for every graph below that doesn't set its own root
 graphs:
   - generator: kagen
     type: file
     graph_name: example-graph
-    root: ${GRAPH_ROOT}
     filename: example-graph.graph
 ```
 ```yaml
@@ -117,7 +119,7 @@ graphs:
 graphs:
   - import: real-world-graphs
     with:
-      root: /scratch/other-graphs   # override for one run
+      root: /scratch/other-graphs   # override for one run, beats the file-level default
 ```
 
 See `examples/suites/common.instances.yaml`, `examples/suites/real-world.instances.yaml`, and `examples/suites/import.suite.yaml`. Parsing lives in `expcore.load_instance_sets()` (discovery) and `expcore.parse_graph_list()` (expansion, incl. imports and `with:` overrides); dedup is `expcore.dedup_inputs()`, applied in `load_suite_from_yaml()`.

--- a/examples/suites/real-world.instances.yaml
+++ b/examples/suites/real-world.instances.yaml
@@ -6,17 +6,19 @@
 # indirection pattern as BUILD_DIR) -- kept as a literal path here so this
 # example runs out of the box without requiring an external env var; see
 # CLAUDE.md for the env-var form.
+#
+# A top-level `root:` (below) applies to every file-based graph in this file
+# that doesn't set its own `root`, so it doesn't need repeating per entry.
 name: real-world-graphs
+root: examples/graphs
 graphs:
   - generator: kagen
     type: file
     graph_name: example-graph-a
-    root: examples/graphs
     filename: graph-a.graph   # placeholder; not read by examples/test-app
     input_format: metis
   - generator: kagen
     type: file
     graph_name: example-graph-b
-    root: examples/graphs
     filename: graph-b.graph
     input_format: metis

--- a/expcore.py
+++ b/expcore.py
@@ -518,9 +518,35 @@ def load_instance_sets(search_paths):
             input_list = get_input_list(data, file)
             if input_list is None:
                 continue
+            default_root = data.get("root")
+            if default_root is not None:
+                input_list = apply_default_root(input_list, default_root)
             name = data.get("name", file[: -len(".instances.yaml")])
             instance_sets[name] = input_list
     return instance_sets
+
+
+def apply_default_root(graph_list, default_root):
+    """Apply an instance-set-file-level default ``root`` to its file-based graphs.
+
+    Only entries that look like on-disk KaGen graphs (``generator: kagen`` with
+    a ``filename``) and don't already set their own ``root`` are touched, so a
+    synthetic graph mixed into the same file, or a further ``import`` entry,
+    never inherits a root/env-var requirement it doesn't need. An entry's own
+    ``root``, or a use-site ``with: {root: ...}`` override at the import site,
+    still takes precedence over this default.
+    """
+    result = []
+    for graph in graph_list:
+        if (
+            isinstance(graph, dict)
+            and graph.get("generator") == "kagen"
+            and "filename" in graph
+            and "root" not in graph
+        ):
+            graph = {**graph, "root": default_root}
+        result.append(graph)
+    return result
 
 
 def parse_graph_list(graph_list, instance_sets=None, _seen=None, overrides=None):


### PR DESCRIPTION
## Summary
Follow-up to #16 (already merged). `root` previously had to be repeated on every graph entry in a registry file, which doesn't scale once a registry holds many real-world graphs. A `*.instances.yaml` file can now set a top-level `root:` applied as a default to every `generator: kagen` entry in that file that has a `filename` and doesn't already set its own `root`.

Import entries and non-file graphs mixed into the same file are deliberately left untouched (`expcore.apply_default_root`), so they never inherit a root/env-var requirement they don't need. An entry's own `root`, or a `with: {root: ...}` override at the import site, still takes precedence over the file-level default.

`examples/suites/real-world.instances.yaml` updated to use the new top-level `root:` instead of repeating it per entry.

## Test plan
- [x] `real-world-graphs` entries (no per-entry `root`) resolve `filename` joined against the file-level `root`
- [x] `with: {root: ...}` at the import site still overrides the file-level default
- [x] `common-graphs` (synthetic KaGen, no `filename`) is unaffected — `root` stays `None`
- [x] A file-level `root: ${VAR}` with an unset env var still raises `ValueError` at suite-load time
- [x] `BUILD_DIR=examples`/`import-example`/`test`/`generic-input-example` suites all run with unchanged failure counts (pre-existing local 64-rank MPI oversubscription limit, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)