### PR TITLE
Add CLI filtering for which jobs get generated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ Key flags:
 - `--fresh`: wipe experiment directory before running
 - `--test`: use test partition on SLURM clusters
 - `--no-job-grouping`: SLURM machine types only. By default, every config/seed/thread-count combination for a given input and core count is packed into one sbatch job file as multiple sequential `mpiexec` invocations. This flag disables that grouping, producing one job file per `mpiexec` invocation instead (job/log/error-log file names and the SLURM time limit become per-invocation rather than aggregated).
+- `--input-filter`: only generate jobs for inputs whose `.name`/`.short_name` (or, for bare file-path inputs, the string itself) contains one of the given substrings (case-insensitive, OR'd across multiple values)
+- `--config-index`: only generate jobs for configs at these 0-based indices, matching the `idx` field written to the suite's `config.json`
+- `--config-filter`: only generate jobs for configs matching all given `key=value` pairs (e.g. `--config-filter variant=bfs1`); values are compared as strings. Combines with `--config-index` (both must pass)
 
 No automated test suite exists. Use the example suite to verify behavior. `examples/test-app` is a stand-in bash "binary" (echoes its args and writes a minimal JSON result); point `BUILD_DIR` at its parent so the suite's `executable: test-app` resolves:
 ```bash

--- a/run-experiments.py
+++ b/run-experiments.py
@@ -107,6 +107,25 @@ def main():
     parser.add_argument("--min-cores", default=None, type=int, help="Lower bound on core counts; overrides suite min_cores (default 1)")
     parser.add_argument("--cores", nargs="*", help="Override suite ncores with an explicit list of core counts or a special keyword: 'pow2' for powers of two (1,2,4,...), 'sqr' for square numbers (1,4,9,16,...), 'sqr-pow2' for powers of two that are also squares (1,4,16,64,...), 'node-size-pow2' for powers-of-two multiples of tasks_per_node")
     parser.add_argument(
+        "--input-filter",
+        nargs="*",
+        help="Only generate jobs for inputs whose name or short (output-directory) name "
+        "contains one of these substrings (case-insensitive).",
+    )
+    parser.add_argument(
+        "--config-index",
+        nargs="*",
+        type=int,
+        help="Only generate jobs for configs at these 0-based indices, matching the "
+        "'idx' field written to the suite's config.json.",
+    )
+    parser.add_argument(
+        "--config-filter",
+        nargs="*",
+        help="Only generate jobs for configs matching all given key=value pairs "
+        "(e.g. --config-filter variant=bfs1 boost=True); values are compared as strings.",
+    )
+    parser.add_argument(
         "-t", "--time-limit",
         default=parse_time_limit(os.environ["TIME_LIMIT"]) if "TIME_LIMIT" in os.environ else None,
         type=parse_time_limit,
@@ -159,6 +178,10 @@ def main():
     )
 
     args = parser.parse_args()
+    if args.config_filter:
+        for item in args.config_filter:
+            if "=" not in item:
+                sys.exit(f"Error: --config-filter entries must be key=value, got {item!r}")
     suites = load_suites(args.suite_files, args.search_dirs)
 
     for suitename in args.suite:
@@ -192,6 +215,21 @@ def main():
 
     for suitename in active_suites:
         suite = suites.get(suitename)
+        if args.input_filter or args.config_index or args.config_filter:
+            index_filter = set(args.config_index) if args.config_index else None
+            kv_filter = parse_config_filter(args.config_filter)
+            matched_inputs = sum(
+                1 for inp in suite.inputs if input_matches_filter(inp, args.input_filter)
+            )
+            matched_configs = sum(
+                1
+                for i, c in enumerate(suite.configs)
+                if config_matches_filter(i, c, index_filter, kv_filter)
+            )
+            print(
+                f"{suitename}: filters match {matched_inputs}/{len(suite.inputs)} inputs, "
+                f"{matched_configs}/{len(suite.configs)} configs"
+            )
         runner = get_runner(args, suite, name_override=effective_name(suitename))
         runner.execute(suite)
 

--- a/runners.py
+++ b/runners.py
@@ -246,13 +246,20 @@ class SharedMemoryRunner(BaseRunner):
             cores_list = _expand_cores_tokens(
                 experiment_suite.cores, min_cores, max_cores, tpn
             )
+        input_filter = getattr(self, "input_filter", None)
+        config_index_filter = getattr(self, "config_index_filter", None)
+        config_filter = getattr(self, "config_filter", None)
         for iinput, input in enumerate(experiment_suite.inputs):
+            if not input_matches_filter(input, input_filter):
+                continue
             for ncores in cores_list:
                 if ncores < min_cores or ncores > max_cores:
                     continue
                 for seed in experiment_suite.seeds:
                     for threads_per_rank in experiment_suite.threads_per_rank:
                         for i, config in enumerate(experiment_suite.configs):
+                            if not config_matches_filter(i, config, config_index_filter, config_filter):
+                                continue
                             local_config = config.copy()
                             mpi_ranks = ncores // threads_per_rank
 
@@ -384,7 +391,12 @@ class SBatchRunner(BaseRunner):
             cores_list = _expand_cores_tokens(
                 experiment_suite.cores, min_cores, max_cores, tpn
             )
+        input_filter = getattr(self, "input_filter", None)
+        config_index_filter = getattr(self, "config_index_filter", None)
+        config_filter = getattr(self, "config_filter", None)
         for iinput, input in enumerate(experiment_suite.inputs):
+            if not input_matches_filter(input, input_filter):
+                continue
             for ncores in cores_list:
                 if ncores < min_cores or ncores > max_cores:
                     continue
@@ -414,6 +426,8 @@ class SBatchRunner(BaseRunner):
                     mpi_ranks = ncores // threads_per_rank
                     ranks_per_node = tasks_per_node // threads_per_rank
                     for i, config in enumerate(experiment_suite.configs):
+                        if not config_matches_filter(i, config, config_index_filter, config_filter):
+                            continue
                         for seed in experiment_suite.seeds:
                             if self.time_limit is not None:
                                 job_time_limit = self.time_limit
@@ -462,7 +476,7 @@ class SBatchRunner(BaseRunner):
                                 with open(job_file, "w+") as job:
                                     job.write(job_script)
                                 njobs += 1
-                if self.group_configs:
+                if self.group_configs and commands:
                     instance_name = self.config_name(iinput, input, cores=ncores)
                     log_path = self.output_directory / f"{instance_name}-log.txt"
                     err_log_path = self.output_directory / f"{instance_name}-err.txt"
@@ -675,6 +689,54 @@ class GenericDistributedMemoryRunner(SBatchRunner):
         return 1
 
 
+def input_matches_filter(input, patterns):
+    """True if `input` should be kept under an --input-filter substring list.
+
+    Matches case-insensitively against both `.name` and `.short_name` for an
+    InputGraph, or against the bare string for a plain file-path input. An
+    empty/None pattern list matches everything.
+    """
+    if not patterns:
+        return True
+    if isinstance(input, expcore.InputGraph):
+        haystacks = [input.name, input.short_name]
+    else:
+        haystacks = [str(input)]
+    haystacks = [h.lower() for h in haystacks]
+    return any(pattern.lower() in haystack for pattern in patterns for haystack in haystacks)
+
+
+def config_matches_filter(index, config, index_filter, kv_filter):
+    """True if config `config` (at 0-based `index`) survives --config-index/--config-filter.
+
+    `index_filter` is a container of indices to keep (None means all indices
+    match). `kv_filter` is a dict of key -> expected-value-as-string; a config
+    must contain every key with a matching (stringified) value. Both filters
+    must pass; either being falsy/None means that filter is not applied.
+    """
+    if index_filter is not None and index not in index_filter:
+        return False
+    if kv_filter:
+        for key, expected in kv_filter.items():
+            actual = config.get(key)
+            if isinstance(actual, dict) and "type" in actual and "value" in actual:
+                actual = actual["value"]
+            if str(actual) != expected:
+                return False
+    return True
+
+
+def parse_config_filter(pairs):
+    """Parse ``--config-filter key=value ...`` CLI tokens into a dict, or None."""
+    if not pairs:
+        return None
+    result = {}
+    for pair in pairs:
+        key, _, value = pair.partition("=")
+        result[key] = value
+    return result
+
+
 def _expand_cores_tokens(tokens, min_cores, max_cores, tasks_per_node=None):
     """Expand a list of ncores tokens into a concrete list of core counts.
 
@@ -772,6 +834,9 @@ def get_runner(args, suite, name_override=None):
         runner.max_cores = max_cores
         runner.min_cores = min_cores
         runner.override_cores = _expand_cores_override(args, suite)
+        runner.input_filter = getattr(args, "input_filter", None)
+        runner.config_index_filter = set(args.config_index) if getattr(args, "config_index", None) else None
+        runner.config_filter = parse_config_filter(getattr(args, "config_filter", None))
         if getattr(args, "copy_binary", False):
             runner.prepare_binary(suite)
         return runner
@@ -845,6 +910,9 @@ def get_runner(args, suite, name_override=None):
     runner.max_cores = max_cores
     runner.min_cores = min_cores
     runner.override_cores = _expand_cores_override(args, suite)
+    runner.input_filter = getattr(args, "input_filter", None)
+    runner.config_index_filter = set(args.config_index) if getattr(args, "config_index", None) else None
+    runner.config_filter = parse_config_filter(getattr(args, "config_filter", None))
     if getattr(args, "copy_binary", False):
         runner.prepare_binary(suite)
     return runner


### PR DESCRIPTION
## Summary
- Add `--input-filter` (substring match on input name/short-name, case-insensitive, OR'd across multiple values) to only generate jobs for a subset of inputs
- Add `--config-index` (0-based, matching `config.json`'s `idx`) and `--config-filter key=value` to only generate jobs for a subset of configs
- Filters compose (AND) and apply as a skip inside the existing per-input/per-config loops, so unfiltered indices/job names stay stable — reproducible subset generation without renumbering
- Prints a `matches N/M inputs, N/M configs` summary before running when any filter is set
- `SBatchRunner` skips writing a job file if a filter leaves it with zero commands

## Test plan
- [x] `BUILD_DIR=examples pipenv run python3 run-experiments.py test --machine shared ...` baseline: 128 jobs run
- [x] `--config-index 0` on `generic-job-file` machine: mpiexec invocations drop from 128 to 8 (matches 1/16 configs × 2 seeds × 4 job files), job file count unchanged (4)
- [x] `--input-filter rgg2d` on `import-example` suite: only the two rgg2d graphs run (12 jobs), others skipped
- [x] `--config-filter variant=bfs1` on `import-example`: only bfs1-variant configs run
- [x] `--input-filter <no-match>`: 0 job files created, no crash
- [x] Malformed `--config-filter` (no `=`) exits with a clear error before loading suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)